### PR TITLE
Fix method definition to not throw exception

### DIFF
--- a/lib/client_side_validations/mongoid/uniqueness.rb
+++ b/lib/client_side_validations/mongoid/uniqueness.rb
@@ -1,6 +1,6 @@
 module ClientSideValidations::Mongoid
   module Uniqueness
-    def client_side_hash(model, attribute)
+    def client_side_hash(model, attribute, force = nil)
       hash = {}
       hash[:message] = model.errors.generate_message(attribute, message_type, options.except(:scope))
       hash[:case_sensitive] = options[:case_sensitive] if options.key?(:case_sensitive)


### PR DESCRIPTION
I'm having trouble getting client_side_validations working w/ Mongoid 3.0 & SimpleForm 2.0. I'm not sure the validators are actually running on the front end. I'm working on the details there, but in the meantime, I found this was broken too.

Thanks!
