### PR TITLE
Allow blank on uniqueness

### DIFF
--- a/lib/client_side_validations/mongoid/uniqueness.rb
+++ b/lib/client_side_validations/mongoid/uniqueness.rb
@@ -4,6 +4,7 @@ module ClientSideValidations::Mongoid
       hash = {}
       hash[:message] = model.errors.generate_message(attribute, message_type, options.except(:scope))
       hash[:case_sensitive] = options[:case_sensitive] if options.key?(:case_sensitive)
+      hash[:allow_blank] = true if options[:allow_blank]
       hash[:id] = model.id unless model.new_record?
       if options.key?(:scope) && options[:scope].present?
         hash[:scope] = Array.wrap(options[:scope]).inject({}) do |scope_hash, scope_item|

--- a/test/mongoid/cases/test_uniqueness_validator.rb
+++ b/test/mongoid/cases/test_uniqueness_validator.rb
@@ -7,6 +7,11 @@ class Mongoid::UniqunessValidatorTest < ClientSideValidations::MongoidTestBase
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@book, :age)
   end
 
+  def test_uniqueness_client_side_hash_allowing_blank
+    expected_hash = { :message => "is already taken", :allow_blank => true }
+    assert_equal expected_hash, UniquenessValidator.new(:attributes => [:author_name], :allow_blank => true).client_side_hash(@book, :author_name)
+  end
+
   def test_uniqueness_client_side_hash_with_custom_message
     expected_hash = { :message => "is not available" }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name], :message => "is not available").client_side_hash(@book, :age)


### PR DESCRIPTION
client_side_validations-mongoid: 3.0.1
client_side_validations: 3.2.1
rais: 3.2.11

allow_blank on uniqueness not effect in client_hash.

Mongoid's document not specified, but allow_blank is work on uniqueness.

I write a test script https://gist.github.com/4642409
