### PR TITLE
Update dependency of mongoid to "~> 3.0"

### DIFF
--- a/client_side_validations-mongoid.gemspec
+++ b/client_side_validations-mongoid.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = ClientSideValidations::Mongoid::VERSION
 
   gem.add_dependency 'client_side_validations', '~> 3.2.0'
-  gem.add_dependency 'mongoid', '~> 3.0.0'
+  gem.add_dependency 'mongoid', '~> 3.0'
 
   gem.add_development_dependency 'bson_ext'
   gem.add_development_dependency 'rails', '~> 3.2.0'


### PR DESCRIPTION
Updated mongoid dependency since 3.1.0 was released a few days ago.
