### PR TITLE
Fix uniqueness client side hash when using inherit

### DIFF
--- a/lib/client_side_validations/mongoid/uniqueness.rb
+++ b/lib/client_side_validations/mongoid/uniqueness.rb
@@ -12,7 +12,9 @@ module ClientSideValidations::Mongoid
         end
       end
 
-      unless model.class.name.demodulize == model.class.name
+      if klass && klass != model.class
+        hash[:class] = klass.name.underscore
+      elsif model.class.name.demodulize != model.class.name
         hash[:class] = model.class.name.underscore
       end
 

--- a/test/mongoid/cases/test_middleware.rb
+++ b/test/mongoid/cases/test_middleware.rb
@@ -8,10 +8,12 @@ class ClientSideValidationsMongoidMiddlewareTest < Test::Unit::TestCase
     # I've been burned enough times with not having the db clear
     # I should probably use a db cleaner instead of this
     Book.delete_all
+    MongoidTestModule::BookNested.delete_all
   end
 
   def teardown
     Book.delete_all
+    MongoidTestModule::BookNested.delete_all
   end
 
   def app
@@ -67,8 +69,8 @@ class ClientSideValidationsMongoidMiddlewareTest < Test::Unit::TestCase
   end
 
   def test_uniqueness_when_resource_is_a_nested_module
-    MongoidTestModule::Book2.create(:author_email => 'book@test.com')
-    get '/validators/uniqueness', { 'mongoid_test_module/book2[author_email]' => 'book@test.com' }
+    MongoidTestModule::BookNested.create(:author_email => 'book@test.com')
+    get '/validators/uniqueness', { 'mongoid_test_module/book_nested[author_email]' => 'book@test.com' }
 
     assert_equal 'false', last_response.body
     assert last_response.ok?

--- a/test/mongoid/cases/test_uniqueness_validator.rb
+++ b/test/mongoid/cases/test_uniqueness_validator.rb
@@ -50,5 +50,13 @@ class Mongoid::UniqunessValidatorTest < ClientSideValidations::MongoidTestBase
     expected_hash = { :message => "is already taken", :class => 'mongoid_test_module/book2' }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@book, :age)
   end
+
+  def test_uniqueness_client_side_hash_when_inherit
+    @book = Book4.new
+    expected_hash = { :message => "is already taken", :class => 'book' }
+    validator = UniquenessValidator.new(:attributes => [:name])
+    validator.setup(Book)
+    assert_equal expected_hash, validator.client_side_hash(@book, :age)
+  end
 end
 

--- a/test/mongoid/cases/test_uniqueness_validator.rb
+++ b/test/mongoid/cases/test_uniqueness_validator.rb
@@ -46,13 +46,13 @@ class Mongoid::UniqunessValidatorTest < ClientSideValidations::MongoidTestBase
   end
 
   def test_uniqueness_client_side_hash_when_nested_module
-    @book = MongoidTestModule::Book2.new
-    expected_hash = { :message => "is already taken", :class => 'mongoid_test_module/book2' }
+    @book = MongoidTestModule::BookNested.new
+    expected_hash = { :message => "is already taken", :class => 'mongoid_test_module/book_nested' }
     assert_equal expected_hash, UniquenessValidator.new(:attributes => [:name]).client_side_hash(@book, :age)
   end
 
   def test_uniqueness_client_side_hash_when_inherit
-    @book = Book4.new
+    @book = BookInherit.new
     expected_hash = { :message => "is already taken", :class => 'book' }
     validator = UniquenessValidator.new(:attributes => [:name])
     validator.setup(Book)

--- a/test/mongoid/cases/test_validations.rb
+++ b/test/mongoid/cases/test_validations.rb
@@ -10,9 +10,9 @@ class Mongoid::ValidationsTest < ClientSideValidations::MongoidTestBase
 
     expected_hash = {
       :author_email => {
-        :uniqueness => [{:message => "is already taken"}]
+        :uniqueness => [{:message => "is already taken", :class => 'book'}]
       }, :author_name => {
-        :uniqueness => [{:message => "is already taken"}],
+        :uniqueness => [{:message => "is already taken", :class => 'book'}],
         :presence => [{:message => "can't be blank"}]
       }
     }

--- a/test/mongoid/models/book.rb
+++ b/test/mongoid/models/book.rb
@@ -8,10 +8,10 @@ class Book
   validates :author_email, :author_name, :uniqueness => true
 end
 
-class Book4 < Book; end
+class BookInherit < Book; end
 
 module MongoidTestModule
-  class Book2
+  class BookNested
     include Mongoid::Document
 
     field :age, :type => Integer

--- a/test/mongoid/models/book.rb
+++ b/test/mongoid/models/book.rb
@@ -8,7 +8,16 @@ class Book
   validates :author_email, :author_name, :uniqueness => true
 end
 
-module MongoidTestModule
-  class Book2 < Book; end
-end
+class Book4 < Book; end
 
+module MongoidTestModule
+  class Book2
+    include Mongoid::Document
+
+    field :age, :type => Integer
+    field :author_name, :type => String
+    field :author_email, :type => String
+
+    validates :author_email, :author_name, :uniqueness => true
+  end
+end


### PR DESCRIPTION
When add an uniqueness validator, validator will store the klass where the validator defined:

https://github.com/mongoid/mongoid/blob/cb86ec4a75712e6908db4ca3eda41cdf6105a331/lib/mongoid/validatable/uniqueness.rb#L29

Then use klass to query uniqueness status:

https://github.com/mongoid/mongoid/blob/cb86ec4a75712e6908db4ca3eda41cdf6105a331/lib/mongoid/validatable/uniqueness.rb#L271

It means when there are two model:

```ruby
class Book
   field :name
   validates :name, :uniqueness => true
end

class Book2 < Book; end
```

It will always use Book to check if the name is uniqueness, and that's what I expected.

So I add class name to client side hash to sync with mongoid's behavior.